### PR TITLE
Update to Cake.Frosting 0.31.0

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Cake MyGet" value="https://www.myget.org/F/cake/api/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Build/Build.csproj
+++ b/src/Build/Build.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cake.FileHelpers" Version="3.1.0" />
-    <PackageReference Include="Cake.Frosting" Version="0.31.0-alpha0002" />
+    <PackageReference Include="Cake.Frosting" Version="0.31.0" />
     <PackageReference Include="Cake.IIS" Version="0.4.1" />
     <PackageReference Include="Cake.NuGet" Version="0.30.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />


### PR DESCRIPTION
* Uses Cake.Core & Cake.Common 0.31.0 ( read more about improvements at https://cakebuild.net/blog/2018/12/cake-v0.31.0-released )
* 0.31.0 is on NuGet.org so nuget.config no longer needed